### PR TITLE
Using MessageTemplate text for EventTelemetry event name instead.

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -78,7 +78,7 @@ namespace Serilog.Sinks.ApplicationInsights
             }
             else
             {
-                var eventTelemetry = new EventTelemetry(renderedMessage);
+                var eventTelemetry = new EventTelemetry(logEvent.MessageTemplate.Text);
 
                 // write logEvent's .Properties to the AI one
                 ForwardLogEventPropertiesToTelemetryProperties(eventTelemetry, logEvent, renderedMessage);


### PR DESCRIPTION
Telemetry event name has length limitation, so it's better to use message template for it.