### PR TITLE
Flush app insights buffer when sink is disposed

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
@@ -29,9 +29,10 @@ namespace Serilog.Sinks.ApplicationInsights
         /// </summary>
         /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient"/>.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
+        /// <param name="flushOnDispose">Flushes the telemetryClient on exit.</param>
         /// <exception cref="ArgumentNullException"><paramref name="telemetryClient"/> is <see langword="null" />.</exception>
-        public ApplicationInsightsEventsSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null)
-            : base(telemetryClient, formatProvider)
+        public ApplicationInsightsEventsSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null, bool flushOnDispose = false)
+            : base(telemetryClient, formatProvider, flushOnDispose)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
         }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.ApplicationInsights
     /// Base class for Microsoft Azure Application Insights based Sinks.
     /// Inspired by their NLog Appender implementation.
     /// </summary>
-    public abstract class ApplicationInsightsSink : ILogEventSink
+    public abstract class ApplicationInsightsSink : ILogEventSink, IDisposable
     {
         /// <summary>
         /// The format provider
@@ -104,6 +104,20 @@ namespace Serilog.Sinks.ApplicationInsights
         /// </summary>
         /// <param name="logEvent">The log event to write.</param>
         public abstract void Emit(LogEvent logEvent);
+
+        #endregion
+
+        #region Implementation of IDisposable
+
+        /// <summary>
+        /// Flush the app insights buffer when disposed
+        /// e.g Serilog 2 - Log.CloseAndFlush();
+        /// </summary>
+        public void Dispose()
+        {
+            TelemetryClient.Flush();
+            System.Threading.Thread.Sleep(1000);
+        }
 
         #endregion
     }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -27,6 +27,8 @@ namespace Serilog.Sinks.ApplicationInsights
     /// </summary>
     public abstract class ApplicationInsightsSink : ILogEventSink, IDisposable
     {
+        readonly bool _flushOnDispose;
+
         /// <summary>
         /// The format provider
         /// </summary>
@@ -42,13 +44,15 @@ namespace Serilog.Sinks.ApplicationInsights
         /// </summary>
         /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient"/>.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
+        /// <param name="flushOnDispose">Flushes the telemetryClient on exit.</param>
         /// <exception cref="ArgumentNullException"><paramref name="telemetryClient"/> cannot be null</exception>
-        protected ApplicationInsightsSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null)
+        protected ApplicationInsightsSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null, bool flushOnDispose = false)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
 
             TelemetryClient = telemetryClient;
             FormatProvider = formatProvider;
+            _flushOnDispose = flushOnDispose;
         }
 
         #region AI specifc Helper methods
@@ -115,8 +119,11 @@ namespace Serilog.Sinks.ApplicationInsights
         /// </summary>
         public void Dispose()
         {
-            TelemetryClient.Flush();
-            System.Threading.Thread.Sleep(1000);
+            if (_flushOnDispose)
+            {
+                TelemetryClient.Flush();
+                System.Threading.Thread.Sleep(1000);
+            }
         }
 
         #endregion

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
@@ -29,9 +29,10 @@ namespace Serilog.Sinks.ApplicationInsights
         /// </summary>
         /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient"/>.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
+        /// <param name="flushOnDispose">Flushes the telemetryClient on exit.</param>
         /// <exception cref="ArgumentNullException"><paramref name="telemetryClient"/> is <see langword="null" />.</exception>
-        public ApplicationInsightsTracesSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null)
-            : base(telemetryClient, formatProvider)
+        public ApplicationInsightsTracesSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null, bool flushOnDispose = false)
+            : base(telemetryClient, formatProvider, flushOnDispose)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
         }


### PR DESCRIPTION
To avoid losing the final events when an app is terminated, made sink disposable and flushed the buffer, as per:
https://azure.microsoft.com/en-us/documentation/articles/app-insights-api-custom-events-metrics

