### PR TITLE
Use rendered message for trace telemetry

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -139,6 +139,7 @@ namespace Serilog.Sinks.ApplicationInsights
         protected void ForwardLogEventPropertiesToTelemetryProperties(ISupportProperties telemetry, LogEvent logEvent, string renderedMessage)
         {
             telemetry.Properties.Add("LogLevel", logEvent.Level.ToString());
+            telemetry.Properties.Add("MessageTemplate", logEvent.MessageTemplate.Text);
             telemetry.Properties.Add("RenderedMessage", renderedMessage);
 
             foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetry.Properties.ContainsKey(property.Key)))

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.ApplicationInsights
 
             var renderedMessage = logEvent.RenderMessage(FormatProvider);
 
-            var traceTelemetry = new TraceTelemetry(logEvent.MessageTemplate.Text)
+            var traceTelemetry = new TraceTelemetry(renderedMessage)
             {
                 Timestamp = logEvent.Timestamp,
                 SeverityLevel = logEvent.Level.ToSeverityLevel()


### PR DESCRIPTION
As proposed in issue #11, this change uses the rendered message in trace telemetry.

I've also add the message template to the telemetry properties, this allows the trace messages to be queried/grouped by message template.
