### PR TITLE
Added ApplicationInsightsPropertyFormatter for flattening complex properties

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -70,6 +70,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsEventsSink.cs" />
+    <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsPropertyFormatter.cs" />
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsSink.cs" />
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsTracesSink.cs" />
     <Compile Include="Sinks\ApplicationInsights\LogEventLevelExtensions.cs" />

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsPropertyFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsPropertyFormatter.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    internal static class ApplicationInsightsPropertyFormatter
+    {
+        private static readonly IDictionary<Type, Action<string, object, IDictionary<string, string>>> LiteralWriters = new Dictionary
+            <Type, Action<string, object, IDictionary<string, string>>>
+        {
+            {typeof (SequenceValue), (k, v, p) => WriteSequenceValue(k, (SequenceValue) v, p)},
+            {typeof (DictionaryValue), (k, v, p) => WriteDictionaryValue(k, (DictionaryValue) v, p)},
+            {typeof (StructureValue), (k, v, p) => WriteStructureValue(k, (StructureValue) v, p)},
+            {typeof (ScalarValue), (k, v, p) => WriteValue(k,((ScalarValue)v).Value,p)},
+            {typeof (DateTime), (k, v, p) => AppendProperty(p,k,((DateTime)v).ToString("o"))},
+            {typeof (DateTimeOffset), (k, v, p) => AppendProperty(p,k,((DateTimeOffset)v).ToString("o"))},
+            {typeof (float), (k, v, p) => AppendProperty(p,k,((float)v).ToString("R", CultureInfo.InvariantCulture))},
+            {typeof (double), (k, v, p) => AppendProperty(p,k,((double)v).ToString("R", CultureInfo.InvariantCulture))},
+        };
+
+        private static void WriteStructureValue(string key, StructureValue structureValue, IDictionary<string, string> properties)
+        {
+            foreach (var eventProperty in structureValue.Properties)
+            {
+                WriteValue(key + "." + eventProperty.Name, eventProperty.Value, properties);
+            }
+        }
+
+        private static void WriteDictionaryValue(string key, DictionaryValue dictionaryValue, IDictionary<string, string> properties)
+        {
+            foreach (var eventProperty in dictionaryValue.Elements)
+            {
+                WriteValue(key + "." + eventProperty.Key.Value, eventProperty.Value, properties);
+            }
+        }
+
+        private static void WriteSequenceValue(string key, SequenceValue sequenceValue, IDictionary<string, string> properties)
+        {
+            int index = 0;
+            foreach (var eventProperty in sequenceValue.Elements)
+            {
+                WriteValue(key + "." + index, eventProperty, properties);
+                index++;
+            }
+            AppendProperty(properties,key + ".Count", index.ToString());
+        }
+
+        public static void WriteValue(string key, object value, IDictionary<string, string> properties)
+        {
+            Action<string, object, IDictionary<string, string>> writer;
+            if (value==null || !LiteralWriters.TryGetValue(value.GetType(), out writer))
+            {
+                AppendProperty(properties, key, value?.ToString());
+                return;
+            }
+            writer(key, value, properties);
+        }
+
+        private static void AppendProperty(IDictionary<string, string> propDictionary, string key, string value)
+        {
+            if (propDictionary.ContainsKey(key))
+            {
+                SelfLog.WriteLine("The key {0} is not unique after simplification. Ingoring new value {1}", key, value);
+                return;
+            }
+            propDictionary.Add(key, value);
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -144,7 +144,7 @@ namespace Serilog.Sinks.ApplicationInsights
 
             foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetry.Properties.ContainsKey(property.Key)))
             {
-                telemetry.Properties.Add(property.Key, property.Value.ToString());
+                ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetry.Properties);
             }
         }
 


### PR DESCRIPTION
Implemented new behavior for AI custom properties for better integration with [Analytics queries](https://azure.microsoft.com/en-us/documentation/articles/app-insights-analytics/)
Fix for #13

Example:
```c#
logger.Information("Got request:{@string} and {@dto} ", "[\"string\"]",
                new
                {
                    number = 1,
                    list = new object[] {1, "test"},
                    inner = new {a = "a", b = "b"},
                });
//Will produce 
```
Old behavior:
```json
{
  "LogLevel": "Information",
  "RenderedMessage": "Got request:\"[\\\"string\\\"]\" and { number: 1, list: [1, \"test\"], inner: { a: \"a\", b: \"b\" } }",
  "string": "\"[\\\"string\\\"]\"",
  "dto": "{ number: 1, list: [1, \"test\"], inner: { a: \"a\", b: \"b\" } }"
}
```
New behavior:
```json
{
  "LogLevel": "Information",
  "MessageTemplate": "Got request:{@string} and {@dto}",
  "RenderedMessage": "Got request:\"[\\\"string\\\"]\" and { number: 1, list: [1, \"test\"], inner: { a: \"a\", b: \"b\" } }",
  "string": "[\"string\"]",
  "dto.number": "1",
  "dto.list.0": "1",
  "dto.list.1": "test",
  "dto.list.Count": "2",
  "dto.inner.a": "a",
  "dto.inner.b": "b"
}