### PR TITLE
Proposal for #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var log = new LoggerConfiguration()
 `LogEvent` instances that have Exceptions are always sent as Exceptions to AI though... well, by default.
 
 
-You can completely customize the type(s) of Telemetry to send for each LogEvent instance and thereby also what to send (all or no LogEvent properties at all), via a bit more bare-metal set of overloads that take a  `Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter` parameter, i.e. like this to send over MetricTelemetries:
+You can customize completely the type(s) of Telemetry to send for each LogEvent instance and also / or what to send (all or no LogEvent properties at all), via a bit more bare-metal set of overloads that take a  `Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter` parameter, i.e. like this to send over MetricTelemetries:
 
 ```csharp
 var log = new LoggerConfiguration()
@@ -45,6 +45,46 @@ private static ITelemetry LogEventsToMetricTelemetryConverter(LogEvent serilogLo
 }
 
 ```
+
+
+.. or alternatively by using the built-in, default TraceTelemetry generation logic, but adapt the Telemetry's Context to include a UserId:
+
+
+```csharp
+public static void Main()
+{
+    var log = new LoggerConfiguration()
+        .WriteTo
+        .ApplicationInsights("<MyApplicationInsightsInstrumentationKey>", ConvertLogEventsToCustomTraceTelemetry)
+        .CreateLogger();
+}
+
+private static ITelemetry ConvertLogEventsToCustomTraceTelemetry(LogEvent logEvent, IFormatProvider formatProvider)
+{
+    // first create a default TraceTelemetry using the sink's default logic
+    // .. but without the log level, and (rendered) message (template) included in the Properties
+    var telemetry = logEvent.ToDefaultTraceTelemetry(
+        formatProvider,
+        includeLogLevelAsProperty: false,
+        includeRenderedMessageAsProperty: false,
+        includeMessageTemplateAsProperty: false);
+
+    // then go ahead and post-process the telemetry's context to contain the user id as desired
+    if (logEvent.Properties.ContainsKey("UserId"))
+    {
+        telemetry.Context.User.Id = logEvent.Properties["UserId"].ToString();
+    }
+
+    // and remove the UserId from the Telemetry .Properties (we don't need redundancies)
+    if (telemetry.Properties.ContainsKey("UserId"))
+    {
+        telemetry.Properties.Remove("UserId");
+    }
+	
+    return telemetry;
+}
+```
+
 
 * [Serilog Documentation](https://github.com/serilog/serilog/wiki)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,27 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-`LogEvent` instances that have Exceptions are always sent as Exceptions to AI though.
+`LogEvent` instances that have Exceptions are always sent as Exceptions to AI though... well, by default.
+
+
+You can completely customize the type(s) of Telemetry to send for each LogEvent instance and thereby also what to send (all or no LogEvent properties at all), via a bit more bare-metal set of overloads that take a  `Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter` parameter, i.e. like this to send over MetricTelemetries:
+
+```csharp
+var log = new LoggerConfiguration()
+    .WriteTo
+	.ApplicationInsights("<MyApplicationInsightsInstrumentationKey>", LogEventsToMetricTelemetryConverter)
+    .CreateLogger();
+
+// ....
+
+private static ITelemetry LogEventsToMetricTelemetryConverter(LogEvent serilogLogEvent, IFormatProvider formatProvider)
+{
+    var metricTelemetry = new MetricTelemetry(/* ...*/);
+    // forward properties from logEvent or ignore them altogether...
+    return metricTelemetry;
+}
+
+```
 
 * [Serilog Documentation](https://github.com/serilog/serilog/wiki)
 

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -1,0 +1,162 @@
+﻿// ---------------------------------------------// Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights;
+
+namespace Serilog.ExtensionMethods
+{
+    /// <summary>
+    /// Extension Methods for <see cref="LogEvent"/> instances.
+    /// </summary>
+    public static class LogEventExtensions
+    {
+        /// <summary>
+        /// The <see cref="LogEvent.Level"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
+        /// </summary>
+        public const string TelemetryPropertiesLogLevel = "LogLevel";
+
+        /// <summary>
+        /// The <see cref="LogEvent.MessageTemplate"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
+        /// </summary>
+        public const string TelemetryPropertiesMessageTemplate = "MessageTemplate";
+
+        /// <summary>
+        /// The result of <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
+        /// </summary>
+        public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
+
+        /// <summary>
+        /// Forwards all <see cref="LogEvent"/> data to the <paramref name="telemetryProperties"/> including the log level,
+        /// rendered message, message template and all <paramref name="logEvent"/> properties to the telemetry.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="telemetryProperties">The telemetry properties.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" />, <paramref name="telemetryProperties" /> or <paramref name="formatProvider" /> is null.</exception>
+        public static void ForwardAllPropertiesToTelemetryProperties(this LogEvent logEvent, ISupportProperties telemetryProperties, IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+            if (telemetryProperties == null) throw new ArgumentNullException("telemetryProperties");
+            if (formatProvider == null) throw new ArgumentNullException("formatProvider");
+
+            var renderedMessage = logEvent.RenderMessage(formatProvider);
+
+            telemetryProperties.Properties.Add(TelemetryPropertiesLogLevel, logEvent.Level.ToString());
+            telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
+            telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, renderedMessage);
+
+            foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
+            {
+                ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetryProperties.Properties);
+            }
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="ExceptionTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="ExceptionTelemetry"/> for the <paramref name="logEvent"/></returns>
+        /// <exception cref="System.ArgumentNullException">logEvent</exception>
+        /// <exception cref="System.ArgumentException">Must have an Exception;logEvent</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
+        public static ITelemetry ToDefaultExceptionTelemetry(this LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", "logEvent");
+            
+            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
+            {
+                SeverityLevel = logEvent.Level.ToSeverityLevel(),
+                HandledAt = ExceptionHandledAt.UserCode,
+                Timestamp = logEvent.Timestamp
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardAllPropertiesToTelemetryProperties(exceptionTelemetry, formatProvider);
+            return exceptionTelemetry;
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="EventTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="EventTelemetry"/> for the <paramref name="logEvent"/> unless the <paramref name="logEvent"/>
+        /// has an Exeption, then a <see cref="ExceptionTelemetry"/> will be returned.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
+        public static ITelemetry ToDefaultEventTelemetry(this LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            if (logEvent.Exception != null)
+            {
+                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
+            }
+            else
+            {
+                var eventTelemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
+                {
+                    Timestamp = logEvent.Timestamp
+                };
+
+                // write logEvent's .Properties to the AI one
+                logEvent.ForwardAllPropertiesToTelemetryProperties(eventTelemetry, formatProvider);
+
+                return eventTelemetry;
+            }
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="TraceTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="TraceTelemetry"/> for the <paramref name="logEvent"/> unless the <paramref name="logEvent"/>
+        /// has an Exeption, then a <see cref="ExceptionTelemetry"/> will be returned.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
+        public static ITelemetry ToDefaultTraceTelemetry(this LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            if (logEvent.Exception != null)
+            {
+                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
+            }
+            else
+            {
+                var renderedMessage = logEvent.RenderMessage(formatProvider);
+
+                var traceTelemetry = new TraceTelemetry(renderedMessage)
+                {
+                    Timestamp = logEvent.Timestamp,
+                    SeverityLevel = logEvent.Level.ToSeverityLevel()
+                };
+
+                // write logEvent's .Properties to the AI one
+                logEvent.ForwardAllPropertiesToTelemetryProperties(traceTelemetry, formatProvider);
+
+                return traceTelemetry;
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2016 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,31 +29,100 @@ namespace Serilog
     public static class LoggerConfigurationApplicationInsightsExtensions
     {
         /// <summary>
-        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights as <see cref="EventTelemetry"/>.
+        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
+        /// using a custom <see cref="ITelemetry"/> converter / constructor.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="instrumentationKey">Required Application Insights instrumentation key.</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// This will be called for every <see cref="LogEvent" /> and is expected to either return a new <see cref="ITelemetry"/> instance that will be sent to AI
+        /// or <see langword="null" /> to drop the log event completely.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">instrumentationKey;Cannot be empty or null.</exception>
-        public static LoggerConfiguration ApplicationInsightsEvents(
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEventToTelemetryConverter" /> is <see langword="null" />.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="instrumentationKey" /> cannot be empty or is <see langword="null" />.</exception>
+        public static LoggerConfiguration ApplicationInsights(
             this LoggerSinkConfiguration loggerConfiguration,
             string instrumentationKey,
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            IFormatProvider formatProvider = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (logEventToTelemetryConverter == null) throw new ArgumentNullException("logEventToTelemetryConverter");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsEventsSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), logEventToTelemetryConverter, formatProvider),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
+        /// using a custom <see cref="ITelemetry"/> converter / constructor.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// This will be called for every <see cref="LogEvent" /> and is expected to either return a new <see cref="ITelemetry"/> instance that will be sent to AI
+        /// or <see langword="null" /> to drop the log event completely.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEventToTelemetryConverter" /> is <see langword="null" />.</exception>
+        public static LoggerConfiguration ApplicationInsights(
+            this LoggerSinkConfiguration loggerConfiguration,
+            TelemetryConfiguration telemetryConfiguration,
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (telemetryConfiguration == null) throw new ArgumentNullException("telemetryConfiguration");
+            if (logEventToTelemetryConverter == null) throw new ArgumentNullException("logEventToTelemetryConverter");
+
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsSink(CreateTelemetryClientFromConfiguration(telemetryConfiguration), logEventToTelemetryConverter, formatProvider),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
+        /// using a custom <see cref="ITelemetry"/> converter / constructor.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="telemetryClient">The telemetry client.</param>
+        /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// This will be called for every <see cref="LogEvent" /> and is expected to either return a new <see cref="ITelemetry"/> instance that will be sent to AI
+        /// or <see langword="null" /> to drop the log event completely.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEventToTelemetryConverter" /> is <see langword="null" />.</exception>
+        public static LoggerConfiguration ApplicationInsights(
+            this LoggerSinkConfiguration loggerConfiguration,
+            TelemetryClient telemetryClient,
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
+            if (telemetryClient == null) throw new ArgumentNullException("logEventToTelemetryConverter");
+
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsEventsSink(telemetryClient, formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
 
@@ -61,32 +130,56 @@ namespace Serilog
         /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights as <see cref="EventTelemetry"/>.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="configuration">Required Application Insights configuration settings.</param>
+        /// <param name="instrumentationKey">Required Application Insights instrumentation key.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Events including all Properties.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// loggerConfiguration
-        /// or
-        /// configuration
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="instrumentationKey" /> cannot be empty or is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsEvents(
             this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration configuration,
+            string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
-            if (configuration == null) throw new ArgumentNullException("configuration");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsEventsSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsEventsSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventToTelemetryConverter),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights as <see cref="EventTelemetry" />.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Events including all Properties.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// /// <exception cref="ArgumentNullException"><paramref name="telemetryConfiguration" /> is <see langword="null" />.</exception>
+        public static LoggerConfiguration ApplicationInsightsEvents(
+            this LoggerSinkConfiguration loggerConfiguration,
+            TelemetryConfiguration telemetryConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null,
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (telemetryConfiguration == null) throw new ArgumentNullException("telemetryConfiguration");
+
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsEventsSink(CreateTelemetryClientFromConfiguration(telemetryConfiguration), formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
 
@@ -97,29 +190,25 @@ namespace Serilog
         /// <param name="telemetryClient">The telemetry client.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
         /// <param name="formatProvider">The format provider.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Events including all Properties.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// loggerConfiguration
-        /// or
-        /// configuration
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsEvents(
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsEventsSink(telemetryClient, formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsEventsSink(telemetryClient, formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
 
@@ -130,25 +219,24 @@ namespace Serilog
         /// <param name="instrumentationKey">Required Application Insights instrumentation key.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Traces including all Properties.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">instrumentationKey;Cannot be empty or null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="instrumentationKey" /> cannot be empty or is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsTraces(
             this LoggerSinkConfiguration loggerConfiguration,
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsTracesSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsTracesSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
 
@@ -156,32 +244,28 @@ namespace Serilog
         /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights as <see cref="TraceTelemetry"/>.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="configuration">Required Application Insights configuration settings.</param>
+        /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Traces including all Properties.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// loggerConfiguration
-        /// or
-        /// configuration
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryConfiguration" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsTraces(
             this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration configuration,
+            TelemetryConfiguration telemetryConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (telemetryConfiguration == null) throw new ArgumentNullException("telemetryConfiguration");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsTracesSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsTracesSink(CreateTelemetryClientFromConfiguration(telemetryConfiguration), formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
 
@@ -192,29 +276,25 @@ namespace Serilog
         /// <param name="telemetryClient">The telemetry client.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
         /// <param name="formatProvider">The format provider.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.
+        /// If none is provided, the Serilog LogEvents will be sent as AI Traces including all Properties.</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// loggerConfiguration
-        /// or
-        /// configuration
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="loggerConfiguration" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsTraces(
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
 
             return loggerConfiguration.Sink(
-                new ApplicationInsightsTracesSink(telemetryClient, formatProvider, logEventDataToTelemetryForwarder),
+                new ApplicationInsightsTracesSink(telemetryClient, formatProvider, logEventToTelemetryConverter),
                 restrictedToMinimumLevel);
         }
         
@@ -246,7 +326,7 @@ namespace Serilog
         /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights as <see cref="EventTelemetry"/>.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="configuration">Required Application Insights configuration settings.</param>
+        /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <returns>
@@ -260,13 +340,13 @@ namespace Serilog
         [Obsolete("This unspecific AI Telemetry Sink will be removed once Serilog Core reaches v2.0, please use either .ApplicationInsightsEvents(..) or .ApplicationInsightsTraces(..)")]
         public static LoggerConfiguration ApplicationInsights(
             this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration configuration,
+            TelemetryConfiguration telemetryConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
-            return loggerConfiguration.ApplicationInsightsEvents(configuration, restrictedToMinimumLevel, formatProvider);
+            return loggerConfiguration.ApplicationInsightsEvents(telemetryConfiguration, restrictedToMinimumLevel, formatProvider);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -34,6 +35,9 @@ namespace Serilog
         /// <param name="instrumentationKey">Required Application Insights instrumentation key.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -43,11 +47,14 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsEventsSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsEventsSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -57,6 +64,9 @@ namespace Serilog
         /// <param name="configuration">Required Application Insights configuration settings.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -69,12 +79,15 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryConfiguration configuration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (configuration == null) throw new ArgumentNullException("configuration");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsEventsSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsEventsSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -84,7 +97,12 @@ namespace Serilog
         /// <param name="telemetryClient">The telemetry client.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
         /// <param name="formatProvider">The format provider.</param>
-        /// <returns></returns>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
         /// <exception cref="System.ArgumentNullException">
         /// loggerConfiguration
         /// or
@@ -94,12 +112,15 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsEventsSink(telemetryClient, formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsEventsSink(telemetryClient, formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -109,6 +130,9 @@ namespace Serilog
         /// <param name="instrumentationKey">Required Application Insights instrumentation key.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -118,11 +142,14 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsTracesSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsTracesSink(CreateTelemetryClientFromInstrumentationkey(instrumentationKey), formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -132,6 +159,9 @@ namespace Serilog
         /// <param name="configuration">Required Application Insights configuration settings.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
         /// <returns>
         /// Logger configuration, allowing configuration to continue.
         /// </returns>
@@ -144,12 +174,15 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryConfiguration configuration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (configuration == null) throw new ArgumentNullException("configuration");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsTracesSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsTracesSink(CreateTelemetryClientFromConfiguration(configuration), formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -159,7 +192,12 @@ namespace Serilog
         /// <param name="telemetryClient">The telemetry client.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
         /// <param name="formatProvider">The format provider.</param>
-        /// <returns></returns>
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
         /// <exception cref="System.ArgumentNullException">
         /// loggerConfiguration
         /// or
@@ -169,12 +207,15 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
 
-            return loggerConfiguration.Sink(new ApplicationInsightsTracesSink(telemetryClient, formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsTracesSink(telemetryClient, formatProvider, logEventDataToTelemetryForwarder),
+                restrictedToMinimumLevel);
         }
         
         /// <summary>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExtensionMethods\LogEventExtensions.cs" />
     <Compile Include="LoggerConfigurationApplicationInsightsExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
@@ -72,6 +73,7 @@
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsEventsSink.cs" />
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsPropertyFormatter.cs" />
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsSink.cs" />
+    <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsSinkBase.cs" />
     <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsTracesSink.cs" />
     <Compile Include="Sinks\ApplicationInsights\LogEventLevelExtensions.cs" />
   </ItemGroup>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.nuspec
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.nuspec
@@ -6,7 +6,7 @@
     <authors>Joerg Battermann</authors>
     <description>Serilog event sink that writes Microsoft Application Insights.</description>
     <language>en-US</language>
-    <releaseNotes>Updated ApplicationInsights to 2.0 and added functionality to send LogEvents as a specific AI Telemetry type: Event(s) or Trace(s).</releaseNotes>
+    <releaseNotes>Users / Developers can now fully customize how and what data is sent by allowing them to construct their own ITelemetry instances for every LogEvent (see Readme.md).</releaseNotes>
     <projectUrl>http://serilog.net</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
@@ -55,7 +55,14 @@ namespace Serilog.Sinks.ApplicationInsights
         {
             if (logEvent == null) throw new ArgumentNullException("logEvent");
 
-            return logEvent.ToDefaultEventTelemetry(formatProvider);
+            if (logEvent.Exception == null)
+            {
+                return logEvent.ToDefaultEventTelemetry(formatProvider);
+            }
+            else
+            {
+                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
@@ -17,75 +17,45 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
+using Serilog.ExtensionMethods;
 
 namespace Serilog.Sinks.ApplicationInsights
 {
     /// <summary>
     /// Writes log events as Events to a Microsoft Azure Application Insights account.
     /// </summary>
-    public class ApplicationInsightsEventsSink : ApplicationInsightsSink
+    public class ApplicationInsightsEventsSink : ApplicationInsightsSinkBase
     {
         /// <summary>
         /// Creates a sink that saves logs as Events to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
         /// </summary>
         /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
-        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.</param>
         /// <exception cref="System.ArgumentNullException">telemetryClient</exception>
         /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
         public ApplicationInsightsEventsSink(
             TelemetryClient telemetryClient,
             IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
-            : base(telemetryClient, formatProvider, logEventDataToTelemetryForwarder)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            : base(telemetryClient, logEventToTelemetryConverter ?? DefaultLogEventToEventTelemetryConverter, formatProvider)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
         }
 
         /// <summary>
-        /// Emits the provided <paramref name="logEvent"/> to AI as an <see cref="EventTelemetry"/>.
+        /// Emits the provided <paramref name="logEvent" /> to AI as an <see cref="EventTelemetry" />.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent"/> is <see langword="null" />.</exception>
-        /// <exception cref="ArgumentException"><paramref name="logEvent"/> must have a <see cref="LogEvent.Exception"/>.</exception>
-        private void TrackAsEvent(LogEvent logEvent)
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">logEvent</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        private static ITelemetry DefaultLogEventToEventTelemetryConverter(LogEvent logEvent, IFormatProvider formatProvider)
         {
             if (logEvent == null) throw new ArgumentNullException("logEvent");
 
-            CheckForAndThrowIfDisposed();
-
-            var eventTelemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
-            {
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            ForwardLogEventDataToTelemetry(logEvent, FormatProvider, eventTelemetry, eventTelemetry);
-
-            TelemetryClient.TrackEvent(eventTelemetry);
+            return logEvent.ToDefaultEventTelemetry(formatProvider);
         }
-
-        #region Overrides of ApplicationInsightsSink
-
-        /// <summary>
-        /// Emit the provided log event to the sink.
-        /// </summary>
-        /// <param name="logEvent">The log event to write.</param>
-        public override void Emit(LogEvent logEvent)
-        {
-            CheckForAndThrowIfDisposed();
-
-            if (logEvent.Exception != null)
-            {
-                TrackAsException(logEvent);
-            }
-            else
-            {
-                TrackAsEvent(logEvent);
-            }
-        }
-
-        #endregion
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -12,302 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 using System;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.ExceptionServices;
-using System.Threading;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Serilog.Core;
 using Serilog.Events;
 
 namespace Serilog.Sinks.ApplicationInsights
 {
     /// <summary>
-    /// Base class for Microsoft Azure Application Insights based Sinks.
-    /// Inspired by their NLog Appender implementation.
+    /// Writes log events to a Microsoft Azure Application Insights account.
     /// </summary>
-    public abstract class ApplicationInsightsSink : ILogEventSink, IDisposable
+    public class ApplicationInsightsSink : ApplicationInsightsSinkBase
     {
-        private long _isDisposing = 0;
-        private long _isDisposed = 0;
-
-        private readonly TelemetryClient _telemetryClient;
-        private readonly IFormatProvider _formatProvider;
-        private readonly Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> _logEventDataToTelemetryForwarder;
-
         /// <summary>
-        /// The <see cref="LogEvent.Level"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesLogLevel = "LogLevel";
-
-        /// <summary>
-        /// The <see cref="LogEvent.MessageTemplate"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesMessageTemplate = "MessageTemplate";
-
-        /// <summary>
-        /// The result of <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is being disposed.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is being disposed; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsDisposing
-        {
-            get
-            {
-                return Interlocked.Read(ref _isDisposing) == 1;
-            }
-            protected set
-            {
-                Interlocked.Exchange(ref _isDisposing, value ? 1 : 0);
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance has been disposed.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance has been disposed; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsDisposed
-        {
-            get
-            {
-                return Interlocked.Read(ref _isDisposed) == 1;
-            }
-            protected set
-            {
-                Interlocked.Exchange(ref _isDisposed, value ? 1 : 0);
-            }
-        }
-
-        /// <summary>
-        /// Gets the format provider.
-        /// </summary>
-        /// <value>
-        /// The format provider.
-        /// </value>
-        protected IFormatProvider FormatProvider
-        {
-            get
-            {
-                CheckForAndThrowIfDisposed();
-
-                return _formatProvider;
-            }
-        }
-
-        /// <summary>
-        /// Gets the log event data to telemetry forwarder.
-        /// </summary>
-        /// <value>
-        /// The log event data to telemetry forwarder.
-        /// </value>
-        protected Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> LogEventDataToTelemetryForwarder
-        {
-            get
-            {
-                CheckForAndThrowIfDisposed();
-
-                return _logEventDataToTelemetryForwarder;
-            }
-        }
-
-        /// <summary>
-        /// Holds the actual Application Insights TelemetryClient that will be used for logging.
-        /// </summary>
-        public TelemetryClient TelemetryClient
-        {
-            get
-            {
-                CheckForAndThrowIfDisposed();
-
-                return _telemetryClient;
-            }
-        }
-
-        /// <summary>
-        /// Creates a sink that saves logs to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
+        /// Creates a sink that saves logs as <see cref="ITelemetry"/> to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
         /// </summary>
         /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
-        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent"/> data to AI <see cref="ITelemetry"/> forwarder
-        /// provides control over what data of each <see cref="LogEvent"/> is sent to Application Insights, particularly the Message itself but also Properties.
-        /// If none is provided, all properties are sent to AI (albeit flattened).
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">telemetryClient</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> cannot be null</exception>
-        protected ApplicationInsightsSink(
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logEventToTelemetryConverter" /> is <see langword="null" />.</exception>
+        public ApplicationInsightsSink(
             TelemetryClient telemetryClient,
-            IFormatProvider formatProvider = null,
-            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            IFormatProvider formatProvider = null)
+            : base(telemetryClient, logEventToTelemetryConverter, formatProvider)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
-
-            _telemetryClient = telemetryClient;
-            _formatProvider = formatProvider;
-            _logEventDataToTelemetryForwarder = logEventDataToTelemetryForwarder ?? DefaultLogEventDataToTelemetryForwarder;
+            if (logEventToTelemetryConverter == null) throw new ArgumentNullException("logEventToTelemetryConverter");
         }
-
-        #region AI specifc Helper methods
-
-        /// <summary>
-        /// Emits the provided <paramref name="logEvent"/> to AI as an <see cref="ExceptionTelemetry"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent"/> is <see langword="null" />.</exception>
-        /// <exception cref="ArgumentException"><paramref name="logEvent"/> must have a <see cref="LogEvent.Exception"/>.</exception>
-        protected void TrackAsException(LogEvent logEvent)
-        {
-            if (logEvent == null) throw new ArgumentNullException("logEvent");
-            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", "logEvent");
-
-            CheckForAndThrowIfDisposed();
-
-            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
-            {
-                SeverityLevel = logEvent.Level.ToSeverityLevel(),
-                HandledAt = ExceptionHandledAt.UserCode,
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            ForwardLogEventDataToTelemetry(logEvent, FormatProvider, exceptionTelemetry, exceptionTelemetry);
-
-            TelemetryClient.TrackException(exceptionTelemetry);
-        }
-
-        /// <summary>
-        /// Forwards the <see cref="LogEvent"/> data to the <paramref name="telemetry"/> and its <paramref name="telemetryProperties"/>.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="telemetry">The telemetry itself.</param>
-        /// <param name="telemetryProperties">The <paramref name="telemetry"/> properties.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" />, <paramref name="formatProvider" />, <paramref name="telemetry" /> or <paramref name="telemetryProperties" /> is null.</exception>
-        protected void ForwardLogEventDataToTelemetry(LogEvent logEvent, IFormatProvider formatProvider, ITelemetry telemetry, ISupportProperties telemetryProperties)
-        {
-            if (logEvent == null) throw new ArgumentNullException("logEvent");
-            if (telemetry == null) throw new ArgumentNullException("telemetry");
-            if (telemetryProperties == null) throw new ArgumentNullException("telemetryProperties");
-            if (formatProvider == null) throw new ArgumentNullException("formatProvider");
-
-            try
-            {
-                LogEventDataToTelemetryForwarder.Invoke(logEvent, formatProvider, telemetry, telemetryProperties);
-            }
-            catch (TargetInvocationException targetInvocationException)
-            {
-                // rethrow original exception (inside the TargetInvocationException)
-                ExceptionDispatchInfo.Capture(targetInvocationException).Throw();
-            }
-        }
-
-
-        /// <summary>
-        /// Default <see cref="LogEvent"/> data forwarder to the <paramref name="telemetry"/> and its <paramref name="telemetryProperties"/>.
-        /// This forwards the the log level, rendered message, message template and all <paramref name="logEvent"/> properties to the telemetry.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="telemetry">The telemetry itself.</param>
-        /// <param name="telemetryProperties">The telemetry properties.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" />, <paramref name="formatProvider" />, <paramref name="telemetry" /> or <paramref name="telemetryProperties" /> is null.</exception>
-        protected virtual void DefaultLogEventDataToTelemetryForwarder(LogEvent logEvent, IFormatProvider formatProvider, ITelemetry telemetry, ISupportProperties telemetryProperties)
-        {
-            if (logEvent == null) throw new ArgumentNullException("logEvent");
-            if (telemetry == null) throw new ArgumentNullException("telemetry");
-            if (telemetryProperties == null) throw new ArgumentNullException("telemetryProperties");
-            if (formatProvider == null) throw new ArgumentNullException("formatProvider");
-
-            var renderedMessage = logEvent.RenderMessage(formatProvider);
-
-            telemetryProperties.Properties.Add(TelemetryPropertiesLogLevel, logEvent.Level.ToString());
-            telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
-            telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, renderedMessage);
-
-            foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
-            {
-                ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetryProperties.Properties);
-            }
-        }
-
-        #endregion AI specifc Helper methods
-
-        #region Implementation of ILogEventSink
-
-        /// <summary>
-        /// Emit the provided log event to the sink.
-        /// </summary>
-        /// <param name="logEvent">The log event to write.</param>
-        public abstract void Emit(LogEvent logEvent);
-
-        #endregion
-
-        #region Implementation of IDisposable
-
-        /// <summary>
-        /// Checks whether this instance has been disposed and if so, throws an <see cref="ObjectDisposedException"/>.
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        protected void CheckForAndThrowIfDisposed()
-        {
-            if (IsDisposed)
-            {
-                throw new ObjectDisposedException(this.GetType().Name);
-            }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <param name="disposeManagedResources"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposeManagedResources)
-        {
-            if (IsDisposing || IsDisposed)
-                return;
-
-            try
-            {
-                IsDisposing = true;
-
-                // we only have managed resources to dispose of
-                if (disposeManagedResources)
-                {
-                    // free managed resources
-                    if (TelemetryClient != null)
-                    {
-                        TelemetryClient.Flush();
-                    }
-                }
-
-                // no unmanaged resources are to be disposed
-            }
-            finally
-            {
-                // but the flags need to be set in either case
-
-                IsDisposed = true;
-                IsDisposing = false;
-            }
-        }
-
-        #endregion Implementation of IDisposable
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
@@ -1,0 +1,298 @@
+﻿// Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    /// <summary>
+    /// Base class for Microsoft Azure Application Insights based Sinks.
+    /// Inspired by their NLog Appender implementation.
+    /// </summary>
+    public abstract class ApplicationInsightsSinkBase : ILogEventSink, IDisposable
+    {
+        private long _isDisposing = 0;
+        private long _isDisposed = 0;
+
+        private readonly TelemetryClient _telemetryClient;
+        private readonly IFormatProvider _formatProvider;
+        private readonly Func<LogEvent, IFormatProvider, ITelemetry> _logEventToTelemetryConverter;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is being disposed.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is being disposed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDisposing
+        {
+            get
+            {
+                return Interlocked.Read(ref _isDisposing) == 1;
+            }
+            protected set
+            {
+                Interlocked.Exchange(ref _isDisposing, value ? 1 : 0);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has been disposed.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has been disposed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDisposed
+        {
+            get
+            {
+                return Interlocked.Read(ref _isDisposed) == 1;
+            }
+            protected set
+            {
+                Interlocked.Exchange(ref _isDisposed, value ? 1 : 0);
+            }
+        }
+
+        /// <summary>
+        /// Gets the format provider.
+        /// </summary>
+        /// <value>
+        /// The format provider.
+        /// </value>
+        protected IFormatProvider FormatProvider
+        {
+            get
+            {
+                CheckForAndThrowIfDisposed();
+
+                return _formatProvider;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="LogEvent"/> to <see cref="ITelemetry"/> converter.
+        /// </summary>
+        /// <value>
+        /// The log event to telemetry converter.
+        /// </value>
+        protected Func<LogEvent, IFormatProvider, ITelemetry> LogEventToTelemetryConverter
+        {
+            get
+            {
+                CheckForAndThrowIfDisposed();
+
+                return _logEventToTelemetryConverter;
+            }
+        }
+
+        /// <summary>
+        /// Holds the actual Application Insights TelemetryClient that will be used for logging.
+        /// </summary>
+        public TelemetryClient TelemetryClient
+        {
+            get
+            {
+                CheckForAndThrowIfDisposed();
+
+                return _telemetryClient;
+            }
+        }
+
+        /// <summary>
+        /// Creates a sink that saves logs to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
+        /// </summary>
+        /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
+        /// <param name="logEventToTelemetryConverter">The <see cref="LogEvent"/> to <see cref="ITelemetry"/> converter.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> cannot be null</exception>
+        protected ApplicationInsightsSinkBase(
+            TelemetryClient telemetryClient,
+            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            IFormatProvider formatProvider = null)
+        {
+            if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
+            if (logEventToTelemetryConverter == null) throw new ArgumentNullException("logEventToTelemetryConverter");
+
+            _telemetryClient = telemetryClient;
+            _formatProvider = formatProvider;
+            _logEventToTelemetryConverter = logEventToTelemetryConverter;
+        }
+
+        #region AI specifc Helper methods
+
+        /// <summary>
+        /// Hands over the <paramref name="telemetry" /> to the AI telemetry client.
+        /// </summary>
+        /// <param name="telemetry">The telemetry.</param>
+        /// <exception cref="System.ArgumentNullException">telemetry</exception>
+        /// <exception cref="System.ArgumentException">This kind of telemetry is not supported, yet;telemetry</exception>
+        protected virtual void TrackTelemetry(ITelemetry telemetry)
+        {
+            if (telemetry == null) throw new ArgumentNullException("telemetry");
+
+            CheckForAndThrowIfDisposed();
+
+            var dependencyTelemetry = telemetry as DependencyTelemetry;
+            if (dependencyTelemetry != null)
+            {
+                TelemetryClient.TrackDependency(dependencyTelemetry);
+                return;
+            }
+
+            var eventTelemetry = telemetry as EventTelemetry;
+            if (eventTelemetry != null)
+            {
+                TelemetryClient.TrackEvent(eventTelemetry);
+                return;
+            }
+
+            var exceptionTelemetry = telemetry as ExceptionTelemetry;
+            if (exceptionTelemetry != null)
+            {
+                TelemetryClient.TrackException(exceptionTelemetry);
+                return;
+            }
+
+            var metricTelemetry = telemetry as MetricTelemetry;
+            if (metricTelemetry != null)
+            {
+                TelemetryClient.TrackMetric(metricTelemetry);
+                return;
+            }
+
+            var pageViewTelemetry = telemetry as PageViewTelemetry;
+            if (pageViewTelemetry != null)
+            {
+                TelemetryClient.TrackPageView(pageViewTelemetry);
+                return;
+            }
+
+            var requestTelemetry = telemetry as RequestTelemetry;
+            if (requestTelemetry != null)
+            {
+                TelemetryClient.TrackRequest(requestTelemetry);
+                return;
+            }
+
+            var traceTelemetry = telemetry as TraceTelemetry;
+            if (traceTelemetry != null)
+            {
+                TelemetryClient.TrackTrace(traceTelemetry);
+                return;
+            }
+
+            // else
+            throw new ArgumentException("This kind of telemetry is not supported, yet", "telemetry");
+        }
+
+        #endregion AI specifc Helper methods
+
+        #region Implementation of ILogEventSink
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public virtual void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+
+            CheckForAndThrowIfDisposed();
+
+            try
+            {
+                var telemetry = LogEventToTelemetryConverter.Invoke(logEvent, FormatProvider);
+                if (telemetry != null)
+                {
+                    TrackTelemetry(telemetry);
+                }
+            }
+            catch (TargetInvocationException targetInvocationException)
+            {
+                // rethrow original exception (inside the TargetInvocationException)
+                ExceptionDispatchInfo.Capture(targetInvocationException).Throw();
+            }
+        }
+
+        #endregion
+
+        #region Implementation of IDisposable
+
+        /// <summary>
+        /// Checks whether this instance has been disposed and if so, throws an <see cref="ObjectDisposedException"/>.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException"></exception>
+        protected void CheckForAndThrowIfDisposed()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposeManagedResources"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposeManagedResources)
+        {
+            if (IsDisposing || IsDisposed)
+                return;
+
+            try
+            {
+                IsDisposing = true;
+
+                // we only have managed resources to dispose of
+                if (disposeManagedResources)
+                {
+                    // free managed resources
+                    if (TelemetryClient != null)
+                    {
+                        TelemetryClient.Flush();
+                    }
+                }
+
+                // no unmanaged resources are to be disposed
+            }
+            finally
+            {
+                // but the flags need to be set in either case
+
+                IsDisposed = true;
+                IsDisposing = false;
+            }
+        }
+
+        #endregion Implementation of IDisposable
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -25,13 +26,20 @@ namespace Serilog.Sinks.ApplicationInsights
     public class ApplicationInsightsTracesSink : ApplicationInsightsSink
     {
         /// <summary>
-        /// Creates a sink that saves logs as Traces to the Application Insights account for the given <paramref name="telemetryClient"/> instance.
+        /// Creates a sink that saves logs as Traces to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
         /// </summary>
-        /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient"/>.</param>
+        /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient"/> is <see langword="null" />.</exception>
-        public ApplicationInsightsTracesSink(TelemetryClient telemetryClient, IFormatProvider formatProvider = null)
-            : base(telemetryClient, formatProvider)
+        /// <param name="logEventDataToTelemetryForwarder">The <see cref="LogEvent" /> data to AI <see cref="ITelemetry" /> forwarder
+        /// provides control over what data of each <see cref="LogEvent" /> is sent to Application Insights, particularly the Message itself but also Properties.
+        /// If none is provided, all properties are sent to AI (albeit flattened).</param>
+        /// <exception cref="System.ArgumentNullException">telemetryClient</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> is <see langword="null" />.</exception>
+        public ApplicationInsightsTracesSink(
+            TelemetryClient telemetryClient,
+            IFormatProvider formatProvider = null,
+            Action<LogEvent, IFormatProvider, ITelemetry, ISupportProperties> logEventDataToTelemetryForwarder = null)
+            : base(telemetryClient, formatProvider, logEventDataToTelemetryForwarder)
         {
             if (telemetryClient == null) throw new ArgumentNullException("telemetryClient");
         }
@@ -56,7 +64,7 @@ namespace Serilog.Sinks.ApplicationInsights
             };
 
             // write logEvent's .Properties to the AI one
-            ForwardLogEventPropertiesToTelemetryProperties(traceTelemetry, logEvent, renderedMessage);
+            ForwardLogEventDataToTelemetry(logEvent, FormatProvider, traceTelemetry, traceTelemetry);
 
             TelemetryClient.TrackTrace(traceTelemetry);
         }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
@@ -57,7 +57,14 @@ namespace Serilog.Sinks.ApplicationInsights
             if (logEvent == null)
                 throw new ArgumentNullException("logEvent");
 
-            return logEvent.ToDefaultTraceTelemetry(formatProvider);
+            if (logEvent.Exception == null)
+            {
+                return logEvent.ToDefaultTraceTelemetry(formatProvider);
+            }
+            else
+            {
+                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
+            }
         }
     }
 }


### PR DESCRIPTION
Allows Sink users to specify their own .ForwardLogEventPropertiesToTelemetryProperties(..) method and thereby giving them control how data (message, properties etc) is sent to AI... and the original one (sending all as mere, flattened properties) is the default one.