### PR TITLE
Add netstandard1.6 support

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -80,7 +80,6 @@ namespace Serilog.ExtensionMethods
                 telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
             }
 
-
             foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
             {
                 ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetryProperties.Properties);
@@ -114,7 +113,7 @@ namespace Serilog.ExtensionMethods
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
             {
                 SeverityLevel = logEvent.Level.ToSeverityLevel(),
-#if !NETSTANDARD1_6
+#if EXCEPTION_TELEMETRY_HANDLED_AT
                 HandledAt = ExceptionHandledAt.UserCode,
 #endif
                 Timestamp = logEvent.Timestamp

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -79,7 +79,7 @@ namespace Serilog.ExtensionMethods
             {
                 telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
             }
-            
+
 
             foreach (var property in logEvent.Properties.Where(property => property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
             {
@@ -110,10 +110,13 @@ namespace Serilog.ExtensionMethods
         {
             if (logEvent == null) throw new ArgumentNullException("logEvent");
             if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", "logEvent");
-            
+
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
             {
                 SeverityLevel = logEvent.Level.ToSeverityLevel(),
+#if !NETSTANDARD1_6
+                HandledAt = ExceptionHandledAt.UserCode,
+#endif
                 Timestamp = logEvent.Timestamp
             };
 

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -114,7 +114,6 @@ namespace Serilog.ExtensionMethods
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
             {
                 SeverityLevel = logEvent.Level.ToSeverityLevel(),
-                HandledAt = ExceptionHandledAt.UserCode,
                 Timestamp = logEvent.Timestamp
             };
 

--- a/src/Serilog.Sinks.ApplicationInsights/project.json
+++ b/src/Serilog.Sinks.ApplicationInsights/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.0-*",
+  "version": "2.2.1-*",
   "description": "Serilog event sink that writes Microsoft Application Insights.",
   "authors": [ "Joerg Battermann" ],
   "packOptions": {

--- a/src/Serilog.Sinks.ApplicationInsights/project.json
+++ b/src/Serilog.Sinks.ApplicationInsights/project.json
@@ -9,18 +9,29 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.0.0",
-    "Microsoft.ApplicationInsights": "2.0.0"
+    "Serilog": "2.0.0"
   },
   "frameworks": {
-    "net45": { },
+    "net45": {
+      "dependencies": {
+        "Microsoft.ApplicationInsights": "2.0.0"
+      }
+    },
     "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.ApplicationInsights": "2.0.0"
+      },
       "imports": [
         "dotnet5.4"
       ]
+    },
+    "netstandard1.6": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights.AspNetCore": "2.0.0"
+        }
+      }
+    },
+    "buildOptions": {
+      "keyFile": "../../assets/Serilog.snk"
     }
-  },
-  "buildOptions": {
-    "keyFile": "../../assets/Serilog.snk"
   }
-}

--- a/src/Serilog.Sinks.ApplicationInsights/project.json
+++ b/src/Serilog.Sinks.ApplicationInsights/project.json
@@ -15,12 +15,14 @@
     "net45": {
       "dependencies": {
         "Microsoft.ApplicationInsights": "2.0.0"
-      }
+      },
+      "buildOptions": { "define": [ "EXCEPTION_TELEMETRY_HANDLED_AT" ] }
     },
     "netstandard1.3": {
       "dependencies": {
         "Microsoft.ApplicationInsights": "2.0.0"
       },
+      "buildOptions": { "define": [ "EXCEPTION_TELEMETRY_HANDLED_AT" ] },
       "imports": [
         "dotnet5.4"
       ]

--- a/src/Serilog.Sinks.ApplicationInsights/project.json
+++ b/src/Serilog.Sinks.ApplicationInsights/project.json
@@ -26,12 +26,12 @@
       ]
     },
     "netstandard1.6": {
-        "dependencies": {
-          "Microsoft.ApplicationInsights.AspNetCore": "2.0.0"
-        }
+      "dependencies": {
+        "Microsoft.ApplicationInsights.AspNetCore": "2.0.0"
       }
-    },
-    "buildOptions": {
-      "keyFile": "../../assets/Serilog.snk"
     }
+  },
+  "buildOptions": {
+    "keyFile": "../../assets/Serilog.snk"
   }
+}


### PR DESCRIPTION
As microsoft have now released: Microsoft.ApplicationInsights.AspNetCore

I wanted to loose the "dotnet5.4" dependancy so i could use this package in our cross platform project.

Here is the work i had to do to achieve this

