### PR TITLE
Remove Microsoft.ApplicationInsights.AspNetCore dependency. Fix Issue #33.

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not sure why Microsoft.ApplicationInsights.AspNetCore is being used here for .Net Standard 1.6 builds, but it shouldn't be necessary. I've updated the reference to include Microsoft.ApplicationInsights instead. This will fix issue #33.