### PR TITLE
Bump version. Use latest stable Serilog.

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog event sink that writes Microsoft Application Insights.</Description>
-    <VersionPrefix>2.2.1</VersionPrefix>
+    <VersionPrefix>2.2.2</VersionPrefix>
     <Authors>Joerg Battermann</Authors>
     <TargetFrameworks>net45;netstandard1.3;netstandard1.6</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.ApplicationInsights</AssemblyName>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0-dev-00855" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Bumping to version 2.2.2 so a new Nuget package can be released with changes from #41 