### PR TITLE
Using Interface instead Func<LogEvent, IFormatProvider, ITelemetry> for sink initialization (especially usefull for appsettings.json)

### DIFF
--- a/serilog-sinks-applicationinsights.sln
+++ b/serilog-sinks-applicationinsights.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{E9D1B5
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.ApplicationInsights", "src\Serilog.Sinks.ApplicationInsights\Serilog.Sinks.ApplicationInsights.csproj", "{B572E129-3568-435F-A8E9-366AD7014D8E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.ApplicationInsights.UnitTest", "src\Serilog.Sinks.ApplicationInsights.UnitTest\Serilog.Sinks.ApplicationInsights.UnitTest.csproj", "{12C45319-D1E4-4D5C-8684-03BCF63FA2AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{B572E129-3568-435F-A8E9-366AD7014D8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B572E129-3568-435F-A8E9-366AD7014D8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B572E129-3568-435F-A8E9-366AD7014D8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12C45319-D1E4-4D5C-8684-03BCF63FA2AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12C45319-D1E4-4D5C-8684-03BCF63FA2AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12C45319-D1E4-4D5C-8684-03BCF63FA2AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12C45319-D1E4-4D5C-8684-03BCF63FA2AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.ApplicationInsights.UnitTest/ConfigTest.cs
+++ b/src/Serilog.Sinks.ApplicationInsights.UnitTest/ConfigTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.ExtensionMethods;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.ApplicationInsights.UnitTest
+{
+    public class LogToTelemetryTestConverter : ILogEventToTelemetryConverter
+    {
+        public ITelemetry Invoke(LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            Console.WriteLine($"write event to telemetry.{logEvent.MessageTemplate} as {logEvent.Level}");
+            return logEvent.ToDefaultTelemetry<EventTelemetry>(formatProvider);
+        }
+    }
+    [TestClass]
+    public class ConfigTest
+    {
+        [TestMethod]
+        public void LoadFromConfigTest()
+        {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile(path: "appsettings.json", optional: false, reloadOnChange: true)
+                .Build();
+
+            var logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
+
+
+            logger.ForContext<ConfigTest>().Information("Hello, world!");
+            logger.ForContext<ConfigTest>().Error("Hello, world!");
+            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Warning("Hello, world!");
+            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Error("Hello, world!");
+            logger.ForContext(Constants.SourceContextPropertyName, "MyApp.Something.Tricky").Verbose("Hello, world!");
+            logger.Fatal(new Exception("blub"), "Fatal Exception");
+        }
+
+        [TestMethod]
+        [DataRow(typeof(RequestTelemetry))]
+        [DataRow(typeof(PageViewTelemetry))]
+        [DataRow(typeof(MetricTelemetry))]
+        [DataRow(typeof(DependencyTelemetry))]
+        [DataRow(typeof(AvailabilityTelemetry))]
+        [ExpectedException(typeof(NotImplementedException))]
+        public void NotImplementedDefaultTelemetryConvertersTest(Type notImplementedType)
+        {
+            var log = new LogEvent(new DateTimeOffset(), LogEventLevel.Debug, null, new MessageTemplate("test", new List<MessageTemplateToken>()), new List<LogEventProperty>());
+            var parameters = new object[]{ log, null, null, null, null };
+            try
+            {
+                typeof(LogEventExtensions).GetMethod(nameof(LogEventExtensions.ToDefaultTelemetry)).MakeGenericMethod(notImplementedType).Invoke(log, parameters);
+            }
+            catch (System.Reflection.TargetInvocationException e)
+            {
+                throw e.InnerException;
+            } 
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void NotSupportedTelemetryTest()
+        {
+            var log = new LogEvent(new DateTimeOffset(), LogEventLevel.Debug, null, new MessageTemplate("test", new List<MessageTemplateToken>()), new List<LogEventProperty>());
+            log.ToDefaultTelemetry<SessionStateTelemetry>(null);
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights.UnitTest/Serilog.Sinks.ApplicationInsights.UnitTest.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights.UnitTest/Serilog.Sinks.ApplicationInsights.UnitTest.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.ApplicationInsights\Serilog.Sinks.ApplicationInsights.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Serilog.Sinks.ApplicationInsights.UnitTest/appsettings.json
+++ b/src/Serilog.Sinks.ApplicationInsights.UnitTest/appsettings.json
@@ -1,0 +1,32 @@
+﻿{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "MyApp.Something.Tricky": "Verbose"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "ApplicationInsights",
+        "Args": {
+          "restrictedToMinimumLevel": "Information",
+          "instrumentationKey": "3c36...",
+          "logEventToTelemetryConverter": "Serilog.Sinks.ApplicationInsights.UnitTest.LogToTelemetryTestConverter, Serilog.Sinks.ApplicationInsights.UnitTest"
+        }
+      },
+      {
+        "Name": "ApplicationInsightsTraces",
+        "Args": {
+          "restrictedToMinimumLevel": "Information",
+          "instrumentationKey": "3c36..."
+        }
+      }
+    ]
+  },
+  "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
+  "Properties": {
+    "Application": "Sample"
+  }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights;
+using System;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Serilog
@@ -48,7 +48,7 @@ namespace Serilog
         public static LoggerConfiguration ApplicationInsights(
             this LoggerSinkConfiguration loggerConfiguration,
             string instrumentationKey,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            ILogEventToTelemetryConverter logEventToTelemetryConverter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
@@ -80,7 +80,7 @@ namespace Serilog
         public static LoggerConfiguration ApplicationInsights(
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryConfiguration telemetryConfiguration,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            ILogEventToTelemetryConverter logEventToTelemetryConverter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
@@ -113,7 +113,7 @@ namespace Serilog
         public static LoggerConfiguration ApplicationInsights(
             this LoggerSinkConfiguration loggerConfiguration,
             TelemetryClient telemetryClient,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            ILogEventToTelemetryConverter logEventToTelemetryConverter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
@@ -145,7 +145,7 @@ namespace Serilog
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
 
@@ -170,13 +170,12 @@ namespace Serilog
         /// /// <exception cref="ArgumentNullException"><paramref name="telemetryConfiguration" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsEvents(
             this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration telemetryConfiguration,
+            TelemetryConfiguration telemetryConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-            if (telemetryConfiguration == null) throw new ArgumentNullException(nameof(telemetryConfiguration));
 
             return loggerConfiguration.Sink(
                 new ApplicationInsightsEventsSink(CreateTelemetryClientFromConfiguration(telemetryConfiguration), formatProvider, logEventToTelemetryConverter),
@@ -202,7 +201,7 @@ namespace Serilog
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (telemetryClient == null) throw new ArgumentNullException(nameof(telemetryClient));
@@ -231,7 +230,7 @@ namespace Serilog
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
 
@@ -256,13 +255,13 @@ namespace Serilog
         /// <exception cref="ArgumentNullException"><paramref name="telemetryConfiguration" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration ApplicationInsightsTraces(
             this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration telemetryConfiguration,
+            TelemetryConfiguration telemetryConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-            if (telemetryConfiguration == null) throw new ArgumentNullException(nameof(telemetryConfiguration));
+            if (telemetryConfiguration == null) telemetryConfiguration = TelemetryConfiguration.Active;
 
             return loggerConfiguration.Sink(
                 new ApplicationInsightsTracesSink(CreateTelemetryClientFromConfiguration(telemetryConfiguration), formatProvider, logEventToTelemetryConverter),
@@ -288,7 +287,7 @@ namespace Serilog
             TelemetryClient telemetryClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (telemetryClient == null) throw new ArgumentNullException(nameof(telemetryClient));

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsEventsSink.cs
@@ -37,32 +37,10 @@ namespace Serilog.Sinks.ApplicationInsights
         public ApplicationInsightsEventsSink(
             TelemetryClient telemetryClient,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
-            : base(telemetryClient, logEventToTelemetryConverter ?? DefaultLogEventToEventTelemetryConverter, formatProvider)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
+            : base(telemetryClient, logEventToTelemetryConverter ?? new DefaultLogEventToTelemetryConverter<EventTelemetry>(), formatProvider)
         {
             if (telemetryClient == null) throw new ArgumentNullException(nameof(telemetryClient));
-        }
-
-        /// <summary>
-        /// Emits the provided <paramref name="logEvent" /> to AI as an <see cref="EventTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">logEvent</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        private static ITelemetry DefaultLogEventToEventTelemetryConverter(LogEvent logEvent, IFormatProvider formatProvider)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            if (logEvent.Exception == null)
-            {
-                return logEvent.ToDefaultEventTelemetry(formatProvider);
-            }
-            else
-            {
-                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
-            }
         }
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -35,7 +35,7 @@ namespace Serilog.Sinks.ApplicationInsights
         /// <exception cref="ArgumentNullException"><paramref name="logEventToTelemetryConverter" /> is <see langword="null" />.</exception>
         public ApplicationInsightsSink(
             TelemetryClient telemetryClient,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            ILogEventToTelemetryConverter logEventToTelemetryConverter,
             IFormatProvider formatProvider = null)
             : base(telemetryClient, logEventToTelemetryConverter, formatProvider)
         {

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
@@ -72,7 +72,9 @@ namespace Serilog.Sinks.ApplicationInsights
         /// <value>
         /// The log event to telemetry converter.
         /// </value>
-        protected Func<LogEvent, IFormatProvider, ITelemetry> LogEventToTelemetryConverter { get; }
+        //protected Func<LogEvent, IFormatProvider, ITelemetry> LogEventToTelemetryConverter { get; }
+
+        protected ILogEventToTelemetryConverter LogEventToTelemetryConverter { get; }
 
         /// <summary>
         /// Holds the actual Application Insights TelemetryClient that will be used for logging.
@@ -88,7 +90,7 @@ namespace Serilog.Sinks.ApplicationInsights
         /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> cannot be null</exception>
         protected ApplicationInsightsSinkBase(
             TelemetryClient telemetryClient,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter,
+            ILogEventToTelemetryConverter logEventToTelemetryConverter,
             IFormatProvider formatProvider = null)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsTracesSink.cs
@@ -37,34 +37,11 @@ namespace Serilog.Sinks.ApplicationInsights
         public ApplicationInsightsTracesSink(
             TelemetryClient telemetryClient,
             IFormatProvider formatProvider = null,
-            Func<LogEvent, IFormatProvider, ITelemetry> logEventToTelemetryConverter = null)
-            : base(telemetryClient, logEventToTelemetryConverter ?? DefaultLogEventToTraceTelemetryConverter, formatProvider)
+            ILogEventToTelemetryConverter logEventToTelemetryConverter = null)
+            : base(telemetryClient, logEventToTelemetryConverter ?? new DefaultLogEventToTelemetryConverter<TraceTelemetry>(), formatProvider)
         {
             if (telemetryClient == null)
                 throw new ArgumentNullException(nameof(telemetryClient));
-        }
-
-        /// <summary>
-        /// Emits the provided <paramref name="logEvent" /> to AI as an <see cref="TraceTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">logEvent</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        private static ITelemetry DefaultLogEventToTraceTelemetryConverter(LogEvent logEvent, IFormatProvider formatProvider)
-        {
-            if (logEvent == null)
-                throw new ArgumentNullException(nameof(logEvent));
-
-            if (logEvent.Exception == null)
-            {
-                return logEvent.ToDefaultTraceTelemetry(formatProvider);
-            }
-            else
-            {
-                return logEvent.ToDefaultExceptionTelemetry(formatProvider);
-            }
         }
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/DefaultLogEventToTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/DefaultLogEventToTelemetryConverter.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Serilog.Events;
+using Serilog.ExtensionMethods;
+using System;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    public class DefaultLogEventToTelemetryConverter<T> : ILogEventToTelemetryConverter
+        where T : ITelemetry
+    {
+        /// <summary>
+        /// Uses <see cref="LogEvent"/> to create a specific telemetry
+        /// </summary>
+        /// <param name="logEvent">current log event from sink</param>
+        /// <param name="formatProvider">format provider for correct localization</param>
+        /// <returns></returns>
+        public ITelemetry Invoke(LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            if (logEvent == null)
+            {
+                throw new ArgumentNullException(nameof(logEvent));
+            }
+
+            if (logEvent.Exception == null)
+            {
+                return logEvent.ToDefaultTelemetry<T>(formatProvider);
+            }
+
+            return logEvent.ToDefaultTelemetry<ExceptionTelemetry>(formatProvider);
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ILogEventToTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ILogEventToTelemetryConverter.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Serilog.Events;
+using System;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    /// <summary>
+    /// Definition of telemtry converter
+    /// </summary>
+    public interface ILogEventToTelemetryConverter
+    {
+        /// <summary>
+        /// Uses <see cref="LogEvent"/> to create a specific telemetry
+        /// </summary>
+        /// <param name="logEvent">current log event from sink</param>
+        /// <param name="formatProvider">format provider for correct localization</param>
+        /// <returns></returns>
+        ITelemetry Invoke(LogEvent logEvent, IFormatProvider formatProvider);
+    }
+}


### PR DESCRIPTION
Hi, I would like to introduce new implementation that fit appsettings.json initialization with some enhancement in mapper implementation.

Replace the Func<,,> with Interface implementation. Creating new generic default converter for logevents. Unit tests are added to the solution.

Removing Fun<> imply breaking changes, but good changes to the project!