### PR TITLE
Changed the mapping for the Fatal SeriLog event level

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/LogEventLevelExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/LogEventLevelExtensions.cs
@@ -39,8 +39,9 @@ namespace Serilog.Sinks.ApplicationInsights
                 case LogEventLevel.Warning:
                     return SeverityLevel.Warning;
                 case LogEventLevel.Error:
-                case LogEventLevel.Fatal:
                     return SeverityLevel.Error;
+                case LogEventLevel.Fatal:
+                    return SeverityLevel.Critical;
             }
 
             return null;


### PR DESCRIPTION
We noticed that the log messages we were creating at the highest severity level (ILogger.LogCritical) were correctly converted to SeriLog's highest severity level (Fatal), but when those trace event were routed to Application Insights, they used the second highest severity level (Error) rather than the highest (Critical).

This change updates the mapping between the SeriLog event level enumeration and the Application Insights ServerityLevel enumeration to support the SeverityLevel.Critical value.