### PR TITLE
Remove empty catch block

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSinkBase.cs
@@ -199,12 +199,7 @@ namespace Serilog.Sinks.ApplicationInsights
                     // attempt to free managed resources
                     try
                     {
-                        // this apparently (see https://github.com/serilog/serilog-sinks-applicationinsights/issues/46#issuecomment-379218037) throws a NullReference Exception on app shutdown..
                         _telemetryClient?.Flush();
-                    }
-                    catch (Exception)
-                    {
-                        // .. and as ugly as THIS is, .Dispose() methods shall not throw exceptions
                     }
                     finally
                     {


### PR DESCRIPTION
The issue with Flush method was fixed in the version 2.6.0-Beta4 of ApplicationInsights.
See https://github.com/Microsoft/ApplicationInsights-dotnet/issues/755