### PR TITLE
misspelled telemetry a few times

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ private static ITelemetry ConvertLogEventsToCustomTraceTelemetry(LogEvent logEve
     return telemetry;
 }
 
-private static ITelemetry GetTelematry(LogEvent logEvent)
+private static ITelemetry GetTelemetry(LogEvent logEvent)
 {
     if (logEvent.Exception != null) {
-        // Exception telematry
+        // Exception telemetry
         return logEvent.ToDefaultExceptionTelemetry(
         formatProvider,
         includeLogLevelAsProperty: false,
@@ -129,7 +129,7 @@ private static ITelemetry GetTelematry(LogEvent logEvent)
         includeMessageTemplateAsProperty: false);
     }
     else {
-        // default telematry
+        // default telemetry
         return logEvent.ToDefaultTraceTelemetry(
         formatProvider,
         includeLogLevelAsProperty: false,
@@ -144,7 +144,7 @@ If you want to skip sending a particular LogEvent, just return `null` from your 
 
 
 ## How, When and Why to Flush Messages Manually
-
+		
 ### Or: Where did my Messages go?
 
 As explained by the [Application Insights documentation](https://azure.microsoft.com/en-us/documentation/articles/app-insights-api-custom-events-metrics/#flushing-data), the default behaviour of the AI client is to buffer messages and send them to AI in batches whenever the client seems fit. However, this may lead to lost messages when your application terminates while there are still unsent messages in said buffer.


### PR DESCRIPTION
love the lib. Just found a few spelling errors in the readme