### PR TITLE
Exceptions and events should have LogLevel along with other properties

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// ---------------------------------------------// Copyright 2016 Serilog Contributors
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights;
@@ -41,87 +42,6 @@ namespace Serilog.ExtensionMethods
         public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
 
         /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="ExceptionTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <returns>An <see cref="ExceptionTelemetry"/> for the <paramref name="logEvent"/></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
-        public static ExceptionTelemetry ToDefaultExceptionTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
-
-            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
-            {
-                SeverityLevel = logEvent.Level.ToSeverityLevel(),
-#if EXCEPTION_TELEMETRY_HANDLED_AT
-                HandledAt = ExceptionHandledAt.UserCode,
-#endif
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(exceptionTelemetry, formatProvider, true, true, true);
-
-            return exceptionTelemetry;
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="EventTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <returns>An <see cref="EventTelemetry"/> for the <paramref name="logEvent"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        public static EventTelemetry ToDefaultEventTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
-            {
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, true, true, true);
-
-            return telemetry;
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="TraceTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <returns>An <see cref="TraceTelemetry"/> for the <paramref name="logEvent"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        public static TraceTelemetry ToDefaultTraceTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            var renderedMessage = logEvent.RenderMessage(formatProvider);
-
-            var telemetry = new TraceTelemetry(renderedMessage)
-            {
-                Timestamp = logEvent.Timestamp,
-                SeverityLevel = logEvent.Level.ToSeverityLevel()
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, false, false, false);
-
-            return telemetry;
-        }
-
-        /// <summary>
         /// Forwards all <see cref="LogEvent" /> data to the <paramref name="telemetryProperties" /> including the log level,
         /// rendered message, message template and all <paramref name="logEvent" /> properties to the telemetry.
         /// </summary>
@@ -135,12 +55,12 @@ namespace Serilog.ExtensionMethods
         /// <param name="includeMessageTemplate">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
         /// <paramref name="telemetryProperties"/> using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" /> or <paramref name="telemetryProperties" /> is null.</exception>
-        private static void ForwardPropertiesToTelemetryProperties(this LogEvent logEvent,
-                                                                   ISupportProperties telemetryProperties,
-                                                                   IFormatProvider formatProvider,
-                                                                   bool includeLogLevel,
-                                                                   bool includeRenderedMessage,
-                                                                   bool includeMessageTemplate)
+        public static void ForwardPropertiesToTelemetryProperties(this LogEvent logEvent,
+            ISupportProperties telemetryProperties,
+            IFormatProvider formatProvider,
+            bool includeLogLevel = false,
+            bool includeRenderedMessage = true,
+            bool includeMessageTemplate = false)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             if (telemetryProperties == null) throw new ArgumentNullException(nameof(telemetryProperties));
@@ -164,6 +84,119 @@ namespace Serilog.ExtensionMethods
             {
                 ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetryProperties.Properties);
             }
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="ExceptionTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
+        /// created <see cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
+        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
+        /// created <see  cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
+        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
+        /// created <see cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
+        /// <returns>An <see cref="ExceptionTelemetry"/> for the <paramref name="logEvent"/></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
+        public static ExceptionTelemetry ToDefaultExceptionTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider,
+            bool includeLogLevelAsProperty = false,
+            bool includeRenderedMessageAsProperty = true,
+            bool includeMessageTemplateAsProperty = false)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
+
+            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
+            {
+                SeverityLevel = logEvent.Level.ToSeverityLevel(),
+#if EXCEPTION_TELEMETRY_HANDLED_AT
+                HandledAt = ExceptionHandledAt.UserCode,
+#endif
+                Timestamp = logEvent.Timestamp
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(
+                exceptionTelemetry,
+                formatProvider,
+                includeLogLevelAsProperty,
+                includeRenderedMessageAsProperty,
+                includeMessageTemplateAsProperty);
+
+            return exceptionTelemetry;
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="EventTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
+        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
+        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
+        /// <returns>An <see cref="EventTelemetry"/> for the <paramref name="logEvent"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        public static EventTelemetry ToDefaultEventTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider,
+            bool includeLogLevelAsProperty = false,
+            bool includeRenderedMessageAsProperty = true,
+            bool includeMessageTemplateAsProperty = false)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
+            {
+                Timestamp = logEvent.Timestamp
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, includeLogLevelAsProperty, includeRenderedMessageAsProperty, includeMessageTemplateAsProperty);
+
+            return telemetry;
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="TraceTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
+        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
+        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
+        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
+        /// <returns>An <see cref="TraceTelemetry"/> for the <paramref name="logEvent"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        public static TraceTelemetry ToDefaultTraceTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider,
+            bool includeLogLevelAsProperty = false,
+            bool includeRenderedMessageAsProperty = false,
+            bool includeMessageTemplateAsProperty = false)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            var renderedMessage = logEvent.RenderMessage(formatProvider);
+
+            var telemetry = new TraceTelemetry(renderedMessage)
+            {
+                Timestamp = logEvent.Timestamp,
+                SeverityLevel = logEvent.Level.ToSeverityLevel()
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, includeLogLevelAsProperty, includeRenderedMessageAsProperty, includeMessageTemplateAsProperty);
+
+            return telemetry;
         }
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// ---------------------------------------------// Copyright 2016 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,9 +58,9 @@ namespace Serilog.ExtensionMethods
         public static void ForwardPropertiesToTelemetryProperties(this LogEvent logEvent,
             ISupportProperties telemetryProperties,
             IFormatProvider formatProvider,
-            bool includeLogLevel = false,
+            bool includeLogLevel = true,
             bool includeRenderedMessage = true,
-            bool includeMessageTemplate = false)
+            bool includeMessageTemplate = true)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             if (telemetryProperties == null) throw new ArgumentNullException(nameof(telemetryProperties));
@@ -103,9 +103,9 @@ namespace Serilog.ExtensionMethods
         public static ExceptionTelemetry ToDefaultExceptionTelemetry(
             this LogEvent logEvent,
             IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
+            bool includeLogLevelAsProperty = true,
             bool includeRenderedMessageAsProperty = true,
-            bool includeMessageTemplateAsProperty = false)
+            bool includeMessageTemplateAsProperty = true)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
@@ -146,9 +146,9 @@ namespace Serilog.ExtensionMethods
         public static EventTelemetry ToDefaultEventTelemetry(
             this LogEvent logEvent,
             IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
+            bool includeLogLevelAsProperty = true,
             bool includeRenderedMessageAsProperty = true,
-            bool includeMessageTemplateAsProperty = false)
+            bool includeMessageTemplateAsProperty = true)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
 

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// ---------------------------------------------// Copyright 2016 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights;
@@ -42,6 +41,87 @@ namespace Serilog.ExtensionMethods
         public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
 
         /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="ExceptionTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="ExceptionTelemetry"/> for the <paramref name="logEvent"/></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
+        public static ExceptionTelemetry ToDefaultExceptionTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
+
+            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
+            {
+                SeverityLevel = logEvent.Level.ToSeverityLevel(),
+#if EXCEPTION_TELEMETRY_HANDLED_AT
+                HandledAt = ExceptionHandledAt.UserCode,
+#endif
+                Timestamp = logEvent.Timestamp
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(exceptionTelemetry, formatProvider, true, true, true);
+
+            return exceptionTelemetry;
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="EventTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="EventTelemetry"/> for the <paramref name="logEvent"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        public static EventTelemetry ToDefaultEventTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
+            {
+                Timestamp = logEvent.Timestamp
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, true, true, true);
+
+            return telemetry;
+        }
+
+        /// <summary>
+        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="TraceTelemetry" />.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="formatProvider">The format provider.</param>
+        /// <returns>An <see cref="TraceTelemetry"/> for the <paramref name="logEvent"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
+        public static TraceTelemetry ToDefaultTraceTelemetry(
+            this LogEvent logEvent,
+            IFormatProvider formatProvider)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            var renderedMessage = logEvent.RenderMessage(formatProvider);
+
+            var telemetry = new TraceTelemetry(renderedMessage)
+            {
+                Timestamp = logEvent.Timestamp,
+                SeverityLevel = logEvent.Level.ToSeverityLevel()
+            };
+
+            // write logEvent's .Properties to the AI one
+            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, false, false, false);
+
+            return telemetry;
+        }
+
+        /// <summary>
         /// Forwards all <see cref="LogEvent" /> data to the <paramref name="telemetryProperties" /> including the log level,
         /// rendered message, message template and all <paramref name="logEvent" /> properties to the telemetry.
         /// </summary>
@@ -55,12 +135,12 @@ namespace Serilog.ExtensionMethods
         /// <param name="includeMessageTemplate">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
         /// <paramref name="telemetryProperties"/> using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" /> or <paramref name="telemetryProperties" /> is null.</exception>
-        public static void ForwardPropertiesToTelemetryProperties(this LogEvent logEvent,
-            ISupportProperties telemetryProperties,
-            IFormatProvider formatProvider,
-            bool includeLogLevel = false,
-            bool includeRenderedMessage = true,
-            bool includeMessageTemplate = false)
+        private static void ForwardPropertiesToTelemetryProperties(this LogEvent logEvent,
+                                                                   ISupportProperties telemetryProperties,
+                                                                   IFormatProvider formatProvider,
+                                                                   bool includeLogLevel,
+                                                                   bool includeRenderedMessage,
+                                                                   bool includeMessageTemplate)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             if (telemetryProperties == null) throw new ArgumentNullException(nameof(telemetryProperties));
@@ -84,119 +164,6 @@ namespace Serilog.ExtensionMethods
             {
                 ApplicationInsightsPropertyFormatter.WriteValue(property.Key, property.Value, telemetryProperties.Properties);
             }
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="ExceptionTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
-        /// created <see cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
-        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
-        /// created <see  cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
-        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
-        /// created <see cref="ExceptionTelemetry.Properties"/> using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
-        /// <returns>An <see cref="ExceptionTelemetry"/> for the <paramref name="logEvent"/></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        /// <exception cref="ArgumentException"><paramref name="logEvent" /> must have a <see cref="LogEvent.Exception" />.</exception>
-        public static ExceptionTelemetry ToDefaultExceptionTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
-            bool includeRenderedMessageAsProperty = true,
-            bool includeMessageTemplateAsProperty = false)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
-
-            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
-            {
-                SeverityLevel = logEvent.Level.ToSeverityLevel(),
-#if EXCEPTION_TELEMETRY_HANDLED_AT
-                HandledAt = ExceptionHandledAt.UserCode,
-#endif
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(
-                exceptionTelemetry,
-                formatProvider,
-                includeLogLevelAsProperty,
-                includeRenderedMessageAsProperty,
-                includeMessageTemplateAsProperty);
-
-            return exceptionTelemetry;
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="EventTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
-        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
-        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
-        /// <returns>An <see cref="EventTelemetry"/> for the <paramref name="logEvent"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        public static EventTelemetry ToDefaultEventTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
-            bool includeRenderedMessageAsProperty = true,
-            bool includeMessageTemplateAsProperty = false)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text)
-            {
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, includeLogLevelAsProperty, includeRenderedMessageAsProperty, includeMessageTemplateAsProperty);
-
-            return telemetry;
-        }
-
-        /// <summary>
-        /// Converts the provided <paramref name="logEvent" /> to an AI <see cref="TraceTelemetry" />.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="includeLogLevelAsProperty">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
-        /// <param name="includeRenderedMessageAsProperty">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
-        /// <param name="includeMessageTemplateAsProperty">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
-        /// created <see cref="ITelemetry"/> Properties using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
-        /// <returns>An <see cref="TraceTelemetry"/> for the <paramref name="logEvent"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logEvent" /> is <see langword="null" />.</exception>
-        public static TraceTelemetry ToDefaultTraceTelemetry(
-            this LogEvent logEvent,
-            IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
-            bool includeRenderedMessageAsProperty = false,
-            bool includeMessageTemplateAsProperty = false)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            var renderedMessage = logEvent.RenderMessage(formatProvider);
-
-            var telemetry = new TraceTelemetry(renderedMessage)
-            {
-                Timestamp = logEvent.Timestamp,
-                SeverityLevel = logEvent.Level.ToSeverityLevel()
-            };
-
-            // write logEvent's .Properties to the AI one
-            logEvent.ForwardPropertiesToTelemetryProperties(telemetry, formatProvider, includeLogLevelAsProperty, includeRenderedMessageAsProperty, includeMessageTemplateAsProperty);
-
-            return telemetry;
         }
     }
 }


### PR DESCRIPTION
Hi, I'd like to propose this small, yet important change.

In the last update (2.6.2) LogLevel stopped getting logged for events and exceptions, which might be considered as a controversial decision inasmuch as it's the key data. Even if by some reason you believe that LogLevel should be excluded, this change doesn't fit the minor version update, and, secondly, there should be a simple way to get it back (e.g. .WriteTo.ApplicationInsightsEvents("KEY", getMyLogLevelBack: true) or something along those lines).

This PR:
Exceptions and events should have LogLevel along with other properties as this is crucial information.