### PR TITLE
Set the Sink as public. 

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.ApplicationInsights
     /// Base class for Microsoft Azure Application Insights based Sinks.
     /// Inspired by their NLog Appender implementation.
     /// </summary>
-    class ApplicationInsightsSink : ILogEventSink, IDisposable
+    public class ApplicationInsightsSink : ILogEventSink, IDisposable
     {
         private long _isDisposing = 0;
         private long _isDisposed = 0;


### PR DESCRIPTION
So we can create the Sink via the LoggerConfiguration.WriteTo.Sink(new ApplicationInsightsSink(...)).

Serilog offers the capability to create the Sink directly. I use this feature via an "Anonymizer" Sink where I suppress in the LogEvent Properties I don't want to send to Azure. The Anonymizer Sink is unable to give the clean logEvent to the applicationInsights sink due to its private protection level.