### PR TITLE
Upgrade to App insights version 2.15.0

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
     <Description>Serilog event sink that writes to Microsoft Application Insights.</Description>
     <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Joerg Battermann, Ivan Gavryliuk</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.ApplicationInsights</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -23,7 +23,7 @@
     <Version>3.1.0</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
     <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
     <Description>Serilog event sink that writes to Microsoft Application Insights.</Description>
     <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Joerg Battermann, Ivan Gavryliuk</Authors>
-    <TargetFrameworks>net452;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.ApplicationInsights</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog event sink that writes to Microsoft Application Insights.</Description>
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
This upgrades the version of app insights to 2.15.0.

As app insights now only supports .NET 4.5.2, .NET 4.6 and .NET Standard 2.0 the Serilog Sink now only supports these versions too.

This resolves #145 and #144 

