### PR TITLE
Implement IAsyncDisposable and use FlushAsync on TelemetryClient

### DIFF
--- a/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
@@ -23,6 +23,7 @@ public abstract class ApplicationInsightsTest
     }
 
     protected ILogger Logger { get; }
+    protected UnitTestTelemetryChannel Channel => _channel;
 
     protected List<ITelemetry> SubmittedTelemetry => _channel.SubmittedTelemetry;
 

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/DisposableTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/DisposableTest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class DisposableTest : ApplicationInsightsTest
+{
+    [Fact]
+    public void Flush_is_called_on_channel_when_logger_is_disposed()
+    {
+        ((IDisposable)Logger).Dispose();
+        Assert.True(Channel.FlushCalled, "Channel.Flush was not called");
+    }
+    
+#if NET6_0_OR_GREATER
+    [Fact]
+    public async Task FlushAsync_is_called_on_channel_when_logger_is_disposed_asynchronously()
+    {
+        await ((IAsyncDisposable)Logger).DisposeAsync();
+        Assert.True(Channel.FlushAsyncCalled, "Channel.FlushAsync was not called");
+    }
+#endif
+}

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/UnitTestTelemetryChannel.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/UnitTestTelemetryChannel.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 
 namespace Serilog.Sinks.ApplicationInsights.Tests;
 
-class UnitTestTelemetryChannel : ITelemetryChannel
+public class UnitTestTelemetryChannel : ITelemetryChannel, IAsyncFlushable
 {
     public List<ITelemetry> SubmittedTelemetry { get; } = new();
+    public bool FlushCalled { get; private set; }
+    public bool FlushAsyncCalled { get; private set; }
 
     public bool? DeveloperMode
     {
@@ -25,6 +29,13 @@ class UnitTestTelemetryChannel : ITelemetryChannel
 
     public void Flush()
     {
+        FlushCalled = true;
+    }
+    
+    public Task<bool> FlushAsync(CancellationToken cancellationToken)
+    {
+        FlushAsyncCalled = true;
+        return Task.FromResult(true);
     }
 
     public void Send(ITelemetry item)


### PR DESCRIPTION
Currently the docs has a whole section on [How, When and Why to Flush Messages Manually](https://github.com/serilog-contrib/serilog-sinks-applicationinsights?tab=readme-ov-file#how-when-and-why-to-flush-messages-manually). We can help consumers limit the risk of losing log messages when application is shutting down by making use of the [`TelemetryClient.FlushAsync()`](https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#flushing-data) method. By implementing `IAsyncDisposable` in `ApplicationInsightsSink` we can call this `FlushAsync()` method which will ensure all log messages are flushed to App Insights. The `Flush()` method will only *enqueue* a flush.

This PR also adds a few tests around channel being flushed when logger is disposed.