### PR TITLE
feat: Pass `TraceId` and `SpanId` to Application Insights

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink for Application Insights.</Description>
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.ApplicationInsights.Channel;
@@ -142,8 +143,13 @@ public abstract class TelemetryConverterBase : ITelemetryConverter
 
         if (telemetryProperties is ITelemetry telemetry)
         {
-            if (logEvent.Properties.TryGetValue(OperationIdProperty, out var operationId))
+            if (logEvent.TraceId is ActivityTraceId traceId)
+                telemetry.Context.Operation.Id = traceId.ToHexString();
+            else if (logEvent.Properties.TryGetValue(OperationIdProperty, out var operationId))
                 telemetry.Context.Operation.Id = operationId.ToString().Trim('\"');
+
+            if (logEvent.SpanId is ActivitySpanId spanId)
+                telemetry.Context.Operation.ParentId = spanId.ToHexString();
 
             if (logEvent.Properties.TryGetValue(VersionProperty, out var version)
                 && telemetry.Context?.Component != null)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -143,13 +143,16 @@ public abstract class TelemetryConverterBase : ITelemetryConverter
 
         if (telemetryProperties is ITelemetry telemetry)
         {
-            if (logEvent.TraceId is ActivityTraceId traceId)
-                telemetry.Context.Operation.Id = traceId.ToHexString();
-            else if (logEvent.Properties.TryGetValue(OperationIdProperty, out var operationId))
+            if (logEvent.Properties.TryGetValue(OperationIdProperty, out var operationId))
                 telemetry.Context.Operation.Id = operationId.ToString().Trim('\"');
+            else
+            {
+                if (logEvent.TraceId is ActivityTraceId traceId)
+                    telemetry.Context.Operation.Id = traceId.ToHexString();
 
-            if (logEvent.SpanId is ActivitySpanId spanId)
-                telemetry.Context.Operation.ParentId = spanId.ToHexString();
+                if (logEvent.SpanId is ActivitySpanId spanId)
+                    telemetry.Context.Operation.ParentId = spanId.ToHexString();
+            }
 
             if (logEvent.Properties.TryGetValue(VersionProperty, out var version)
                 && telemetry.Context?.Component != null)

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -40,6 +40,14 @@ public class EventTelemetryConverterTest : ApplicationInsightsTest
     }
 
     [Fact]
+    public void TraceIdAndSpanIdDefaultByDefault()
+    {
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Null(LastSubmittedEventTelemetry.Context.Operation.Id);
+        Assert.Null(LastSubmittedEventTelemetry.Context.Operation.ParentId);
+    }
+
+    [Fact]
     public void TraceIdAndSpanIdAreSet()
     {
         using Activity activity = new("TestActivity");

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+﻿using System;
+using System.Diagnostics;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
 namespace Serilog.Sinks.ApplicationInsights.Tests;
@@ -35,5 +37,26 @@ public class EventTelemetryConverterTest : ApplicationInsightsTest
     {
         Logger.Information("Hello, {@MyData}", new { Foo = "foo", Bar = 123 });
         Assert.Equal("{\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedEventTelemetry.Properties["MyData"]);
+    }
+
+    [Fact]
+    public void TraceIdAndSpanIdAreSet()
+    {
+        using Activity activity = new("TestActivity");
+        activity.Start();
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Equal(activity.TraceId.ToHexString(), LastSubmittedEventTelemetry.Context.Operation.Id);
+        Assert.Equal(activity.SpanId.ToHexString(), LastSubmittedEventTelemetry.Context.Operation.ParentId);
+    }
+
+    [Fact]
+    public void OperationIdTakesPrecedenceOverTraceId()
+    {
+        using Activity activity = new("TestActivity");
+        activity.Start();
+        string operationId = Guid.NewGuid().ToString("N");
+        Logger.Information("Hello, {operationId}!", operationId);
+        Assert.Equal(operationId, LastSubmittedEventTelemetry.Context.Operation.Id);
+        Assert.Null(LastSubmittedEventTelemetry.Context.Operation.ParentId);
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -40,6 +40,14 @@ public class TraceTelemetryConverterTest : ApplicationInsightsTest
     }
 
     [Fact]
+    public void TraceIdAndSpanIdDefaultByDefault()
+    {
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Null(LastSubmittedTraceTelemetry.Context.Operation.Id);
+        Assert.Null(LastSubmittedTraceTelemetry.Context.Operation.ParentId);
+    }
+
+    [Fact]
     public void TraceIdAndSpanIdAreSet()
     {
         using Activity activity = new("TestActivity");

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+﻿using System;
+using System.Diagnostics;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
 namespace Serilog.Sinks.ApplicationInsights.Tests;
@@ -35,5 +37,26 @@ public class TraceTelemetryConverterTest : ApplicationInsightsTest
     {
         Logger.Information("Hello, {@MyData}", new { Foo = "foo", Bar = 123 });
         Assert.Equal("{\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedTraceTelemetry.Properties["MyData"]);
+    }
+
+    [Fact]
+    public void TraceIdAndSpanIdAreSet()
+    {
+        using Activity activity = new("TestActivity");
+        activity.Start();
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Equal(activity.TraceId.ToHexString(), LastSubmittedTraceTelemetry.Context.Operation.Id);
+        Assert.Equal(activity.SpanId.ToHexString(), LastSubmittedTraceTelemetry.Context.Operation.ParentId);
+    }
+
+    [Fact]
+    public void OperationIdTakesPrecedenceOverTraceId()
+    {
+        using Activity activity = new("TestActivity");
+        activity.Start();
+        string operationId = Guid.NewGuid().ToString("N");
+        Logger.Information("Hello, {operationId}!", operationId);
+        Assert.Equal(operationId, LastSubmittedTraceTelemetry.Context.Operation.Id);
+        Assert.Null(LastSubmittedTraceTelemetry.Context.Operation.ParentId);
     }
 }


### PR DESCRIPTION
If present, the log event's `SpanId` and `TraceId` get passed to the AI context.

The change also contains some NuGet package updates, mostly to enable access to the `LogEvent.SpanId` and `LogEvent.TraceId` in the first place.

Note that the support for the `operationId` context property being used as the `Context.Operation.Id` is retained, and does take precedence over `LogEvent.TraceId`, so that this change should not be breaking.

Closes #220